### PR TITLE
Guess WordPress version

### DIFF
--- a/detector.js
+++ b/detector.js
@@ -19,7 +19,7 @@
 		'generator': {
 			'Joomla': /joomla/i,
 			'vBulletin': /vBulletin/i,
-			'WordPress': /wordPress/i,
+			'WordPress': /WordPress\s*(.*)/i,
 			'XOOPS': /xoops/i,
 			'Plone': /plone/i,
 			'MediaWiki': /MediaWiki/i,


### PR DESCRIPTION
Add a regular expression, which optionally extracts the WordPress version from the generator meta tag.
