### PR TITLE
Update sniffer rule for disqus

### DIFF
--- a/detector.js
+++ b/detector.js
@@ -99,7 +99,7 @@
 		'MooTools': /mootools/i,
 		'Dojo': /dojo(\.xd)?\.js/i,
 		'script.aculo.us': /scriptaculous\.js/i,
-		'Disqus': /disqus.com\/forums/i,
+		'Disqus': /disqus.com\//i,
 		'GetSatisfaction': /getsatisfaction\.com\/feedback/i,
 		'Wibiya': /wibiya\.com\/Loaders\//i,
 		'reCaptcha': /(google\.com\/recaptcha|api\.recaptcha\.net\/)/i,


### PR DESCRIPTION
Chromesniffer failed to detect disqus on http://www.climagic.org/txt/tar-manpage-commentary.html

There would probably be a more stricter way, but unless somebody comes with a suggestion I'll keep it this way.
