### PR TITLE
Update detector.js

### DIFF
--- a/detector.js
+++ b/detector.js
@@ -234,7 +234,7 @@
       return window.Piwik;
     },
     'IPB': function () {
-      return window.IPBoard;
+      return ( window.IPBoard || window.ipsSettings );
     },
     'MyBB': function () {
       return window.MyBB;


### PR DESCRIPTION
IPB (now IPS Suite) v4 does not use the IPBoard object.